### PR TITLE
Commit the permission fragment asynchronously

### DIFF
--- a/kpermissions/src/main/kotlin/com.fondesa.kpermissions/request/runtime/FragmentRuntimePermissionHandlerProvider.kt
+++ b/kpermissions/src/main/kotlin/com.fondesa.kpermissions/request/runtime/FragmentRuntimePermissionHandlerProvider.kt
@@ -43,16 +43,9 @@ open class FragmentRuntimePermissionHandlerProvider(private val manager: Fragmen
         if (fragment == null) {
             // Create the Fragment delegated to handle permissions.
             fragment = createPermissionHandlerFragment()
-            val transaction = manager.beginTransaction()
+            manager.beginTransaction()
                 .add(fragment, FRAGMENT_TAG)
-
-            // Commit the fragment synchronously.
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                transaction.commitNowAllowingStateLoss()
-            } else {
-                transaction.commitAllowingStateLoss()
-                manager.executePendingTransactions()
-            }
+                .commitAllowingStateLoss()
         }
         return fragment
     }


### PR DESCRIPTION
<!-- 
Make sure you've read the file `CONTRIBUTING.md` before submit the PR. 
Any HTML comment will be stripped when the markdown is rendered, so you don't need to delete them.
-->

### Description
<!--
Describe the changes you have made on a high level in the project.
If this PR is related to an issue, reference it here.
-->
Now the permission `Fragment` will be attached asynchronously without using `commitNow()` or `executePendingTransactions()`.

### Motivation
<!--
If this solves a bug, provide the steps to reproduce it or reference the issue, if opened.
In the other cases, specify why this change or this new feature is required or why
it can be helpful to the other users. 
-->
This PR fixes the crash https://github.com/Fondesa/KPermissions/issues/32.