### PR TITLE
Swap resuming continuation with remove listener

### DIFF
--- a/kpermissions-coroutines/src/main/kotlin/com/fondesa/kpermissions/coroutines/SuspendExtensions.kt
+++ b/kpermissions-coroutines/src/main/kotlin/com/fondesa/kpermissions/coroutines/SuspendExtensions.kt
@@ -32,8 +32,8 @@ import kotlin.coroutines.resume
 suspend fun PermissionRequest.sendSuspend(): List<PermissionStatus> = suspendCancellableCoroutine { continuation ->
     val listener = object : PermissionRequest.Listener {
         override fun onPermissionsResult(result: List<PermissionStatus>) {
-            continuation.resume(result)
             removeListener(this)
+            continuation.resume(result)
         }
     }
     addListener(listener)


### PR DESCRIPTION
It's a recommended practice to resume the `Continuation` as the last instruction in a function.

Thanks to **@recover_relax** from Reddit which pointed it out