### PR TITLE
Remove unnecessary Kotlin stdlib declarations

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -47,7 +47,6 @@ dependencies {
     implementation deps.bintrayPlugin
     implementation deps.dokkaPlugin
     implementation deps.gitHubReleasePlugin
-    implementation deps.kotlinStdLib
 }
 
 configurations.all {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,7 +22,6 @@ android.defaultConfig.applicationId "com.fondesa.kpermissions.sample"
 dependencies {
     implementation project(":kpermissions")
     implementation Deps.androidxAppCompat
-    implementation Deps.kotlinStdLib
 
     debugImplementation Deps.leakCanary
 }


### PR DESCRIPTION
Since Kotlin 1.4 they are no longer needed.
Still maintaining the `api` dependency in `:kpermissions` to make explicit the dependency used in the POM file.