### PR TITLE
Fix result launcher with implicit permissions and when requested before fragment is created

### DIFF
--- a/kpermissions/src/main/kotlin/com.fondesa.kpermissions/request/runtime/ResultLauncherRuntimePermissionHandler.kt
+++ b/kpermissions/src/main/kotlin/com.fondesa.kpermissions/request/runtime/ResultLauncherRuntimePermissionHandler.kt
@@ -33,7 +33,9 @@ internal class ResultLauncherRuntimePermissionHandler : Fragment(), RuntimePermi
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        pendingPermissions = savedInstanceState?.getStringArray(KEY_PENDING_PERMISSIONS)
+        if (pendingPermissions == null) {
+            pendingPermissions = savedInstanceState?.getStringArray(KEY_PENDING_PERMISSIONS)
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/kpermissions/src/main/kotlin/com.fondesa.kpermissions/request/runtime/ResultLauncherRuntimePermissionHandler.kt
+++ b/kpermissions/src/main/kotlin/com.fondesa.kpermissions/request/runtime/ResultLauncherRuntimePermissionHandler.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.Fragment
 import com.fondesa.kpermissions.PermissionStatus
 import com.fondesa.kpermissions.allGranted
 import com.fondesa.kpermissions.extension.checkRuntimePermissionsStatus
+import com.fondesa.kpermissions.extension.isPermissionGranted
 
 /**
  * Implementation of [RuntimePermissionHandler] which used the new [ActivityResultContracts] API to manage the permissions' request.
@@ -94,7 +95,9 @@ internal class ResultLauncherRuntimePermissionHandler : Fragment(), RuntimePermi
         // Get the listener for this set of permissions.
         // If it's null, the permissions can't be notified.
         val listener = listeners[pendingPermissions.toSet()] ?: return
-        val result = permissionsResult.map { (permission, isGranted) ->
+        val context = requireContext()
+        val result = pendingPermissions.map { permission ->
+            val isGranted = permissionsResult.getOrElse(permission) { context.isPermissionGranted(permission) }
             when {
                 isGranted -> PermissionStatus.Granted(permission)
                 shouldShowRequestPermissionRationale(permission) -> PermissionStatus.Denied.ShouldShowRationale(permission)

--- a/kpermissions/src/test/kotlin/com/fondesa/kpermissions/request/runtime/ResultLauncherRuntimePermissionHandlerTest.kt
+++ b/kpermissions/src/test/kotlin/com/fondesa/kpermissions/request/runtime/ResultLauncherRuntimePermissionHandlerTest.kt
@@ -219,7 +219,7 @@ class ResultLauncherRuntimePermissionHandlerTest {
     }
 
     @Test
-    fun `When Fragment is not added yet, the permissions are handled when it will be attached`() {
+    fun `When Fragment is not added yet and the permissions are granted, the permissions are handled when it will be attached`() {
         fragment.attachListener(permissions, listener)
         context.grantPermissions(*permissions)
         whenever(fragment.isAdded) doReturn false
@@ -229,6 +229,23 @@ class ResultLauncherRuntimePermissionHandlerTest {
         verify(listener, never()).onPermissionsResult(any())
 
         fragment.onAttach(context)
+        fragment.onCreate(null)
+
+        verify(listener).onPermissionsResult(permissions.map(PermissionStatus::Granted))
+    }
+
+    @Test
+    fun `When Fragment is not added yet and the permissions are not granted, the permissions are handled when it will be attached`() {
+        fragment.attachListener(permissions, listener)
+        whenever(fragment.isAdded) doReturn false
+
+        fragment.handleRuntimePermissions(permissions)
+
+        verify(listener, never()).onPermissionsResult(any())
+
+        fragment.onAttach(context)
+        fragment.onCreate(null)
+        fragment.onPermissionsResult(firstPermission to true, secondPermission to true)
 
         verify(listener).onPermissionsResult(permissions.map(PermissionStatus::Granted))
     }

--- a/kpermissions/src/test/kotlin/com/fondesa/kpermissions/request/runtime/ResultLauncherRuntimePermissionHandlerTest.kt
+++ b/kpermissions/src/test/kotlin/com/fondesa/kpermissions/request/runtime/ResultLauncherRuntimePermissionHandlerTest.kt
@@ -157,6 +157,51 @@ class ResultLauncherRuntimePermissionHandlerTest {
     }
 
     @Test
+    fun `When permissions result is received with implicit permissions in the manifest, the listeners are notified`() {
+        fragment.attachListener(permissions, listener)
+        fragment.handleRuntimePermissions(permissions)
+        context.grantPermissions(firstPermission, secondPermission)
+
+        fragment.onPermissionsResult()
+
+        verify(listener).onPermissionsResult(permissions.map(PermissionStatus::Granted))
+    }
+
+    @Test
+    fun `When permissions result is received with implicit permissions not in the manifest, the listeners are notified`() {
+        fragment.attachListener(permissions, listener)
+        fragment.handleRuntimePermissions(permissions)
+        fragment.stubRationaleResult(firstPermission, true)
+        fragment.stubRationaleResult(secondPermission, false)
+
+        fragment.onPermissionsResult()
+
+        verify(listener).onPermissionsResult(
+            listOf(
+                PermissionStatus.Denied.ShouldShowRationale(firstPermission),
+                PermissionStatus.Denied.Permanently(secondPermission)
+            )
+        )
+    }
+
+    @Test
+    fun `When permissions result is received without some permissions, the listeners are notified`() {
+        fragment.attachListener(permissions, listener)
+        fragment.handleRuntimePermissions(permissions)
+        fragment.stubRationaleResult(firstPermission, true)
+        context.grantPermissions(secondPermission)
+
+        fragment.onPermissionsResult(firstPermission to false)
+
+        verify(listener).onPermissionsResult(
+            listOf(
+                PermissionStatus.Denied.ShouldShowRationale(firstPermission),
+                PermissionStatus.Granted(secondPermission)
+            )
+        )
+    }
+
+    @Test
     fun `When permissions result is received with granted permissions, the listeners are notified`() {
         fragment.attachListener(permissions, listener)
         fragment.handleRuntimePermissions(permissions)


### PR DESCRIPTION
### Description
<!--
Describe the changes you have made on a high level in the project.
If this PR is related to an issue, reference it here.
-->
Related bug #213 

