### PR TITLE
Fix ConcurrentModificationException on request listeners

### DIFF
--- a/kpermissions/src/main/kotlin/com.fondesa.kpermissions/request/BasePermissionRequest.kt
+++ b/kpermissions/src/main/kotlin/com.fondesa.kpermissions/request/BasePermissionRequest.kt
@@ -21,17 +21,20 @@ package com.fondesa.kpermissions.request
  * that must be the same to all its subclasses.
  */
 public abstract class BasePermissionRequest : PermissionRequest {
-    protected val listeners: MutableSet<PermissionRequest.Listener> = mutableSetOf()
+    // Avoids ConcurrentModificationException when updating the set while iterating on it in another thread.
+    // https://github.com/fondesa/kpermissions/issues/288
+    protected val listeners: Set<PermissionRequest.Listener> get() = mutableListeners.toSet()
+    private val mutableListeners: MutableSet<PermissionRequest.Listener> = mutableSetOf()
 
     override fun addListener(listener: PermissionRequest.Listener) {
-        listeners += listener
+        mutableListeners += listener
     }
 
     override fun removeListener(listener: PermissionRequest.Listener) {
-        listeners -= listener
+        mutableListeners -= listener
     }
 
     override fun removeAllListeners() {
-        listeners.clear()
+        mutableListeners.clear()
     }
 }


### PR DESCRIPTION

<!-- Make sure you've read the file `CONTRIBUTING.md` before submit the PR. -->

### Description
<!--
Describe the changes you have made on a high level in the project.
If this PR is related to an issue, reference it here.
-->
The extension `send { }` can remove the listener from the set while the implementations of `PermissionRequest` are iterating on it.
This can cause a `ConcurrentModificationException`.

Fixes: https://github.com/fondesa/kpermissions/issues/288
