### PR TITLE
Handle multiple instances of PermissionRequest built in the same class

### DIFF
--- a/kpermissions/src/main/kotlin/com/fondesa/kpermissions/request/runtime/ResultLauncherRuntimePermissionHandler.kt
+++ b/kpermissions/src/main/kotlin/com/fondesa/kpermissions/request/runtime/ResultLauncherRuntimePermissionHandler.kt
@@ -63,8 +63,7 @@ internal open /* open for testing */ class ResultLauncherRuntimePermissionHandle
     private fun handleRuntimePermissionsWhenAdded(permissions: Array<out String>) {
         // Get the listener for this set of permissions.
         // If it's null, the permissions can't be notified.
-        val listeners = listeners[permissions.toSet()]
-        if (listeners.isNullOrEmpty()) return
+        val listeners = listeners[permissions.toSet()] ?: return
         val activity = requireActivity()
         val currentStatus = activity.checkRuntimePermissionsStatus(permissions.toList())
         val areAllGranted = currentStatus.allGranted()
@@ -97,8 +96,7 @@ internal open /* open for testing */ class ResultLauncherRuntimePermissionHandle
         this.pendingPermissions = null
         // Get the listener for this set of permissions.
         // If it's null, the permissions can't be notified.
-        val listeners = listeners[pendingPermissions.toSet()]
-        if (listeners.isNullOrEmpty()) return
+        val listeners = listeners[pendingPermissions.toSet()] ?: return
         val context = requireContext()
         val result = pendingPermissions.map { permission ->
             val isGranted = permissionsResult.getOrElse(permission) { context.isPermissionGranted(permission) }

--- a/kpermissions/src/main/kotlin/com/fondesa/kpermissions/request/runtime/ResultLauncherRuntimePermissionHandler.kt
+++ b/kpermissions/src/main/kotlin/com/fondesa/kpermissions/request/runtime/ResultLauncherRuntimePermissionHandler.kt
@@ -22,7 +22,7 @@ internal open /* open for testing */ class ResultLauncherRuntimePermissionHandle
         ActivityResultContracts.RequestMultiplePermissions(),
         ::onPermissionsResult
     )
-    private val listeners = mutableMapOf<Set<String>, RuntimePermissionHandler.Listener>()
+    private val listeners = mutableMapOf<Set<String>, MutableSet<RuntimePermissionHandler.Listener>>()
     private var pendingHandleRuntimePermissions: (() -> Unit)? = null
     private var pendingPermissions: Array<out String>? = null
 
@@ -48,7 +48,8 @@ internal open /* open for testing */ class ResultLauncherRuntimePermissionHandle
         permissions: Array<out String>,
         listener: RuntimePermissionHandler.Listener
     ) {
-        listeners[permissions.toSet()] = listener
+        val permissionsSet = listeners.getOrPut(permissions.toSet()) { mutableSetOf() }
+        permissionsSet += listener
     }
 
     override fun handleRuntimePermissions(permissions: Array<out String>) {
@@ -62,7 +63,8 @@ internal open /* open for testing */ class ResultLauncherRuntimePermissionHandle
     private fun handleRuntimePermissionsWhenAdded(permissions: Array<out String>) {
         // Get the listener for this set of permissions.
         // If it's null, the permissions can't be notified.
-        val listener = listeners[permissions.toSet()] ?: return
+        val listeners = listeners[permissions.toSet()]
+        if (listeners.isNullOrEmpty()) return
         val activity = requireActivity()
         val currentStatus = activity.checkRuntimePermissionsStatus(permissions.toList())
         val areAllGranted = currentStatus.allGranted()
@@ -74,7 +76,7 @@ internal open /* open for testing */ class ResultLauncherRuntimePermissionHandle
             // Request the permissions.
             requestRuntimePermissions(permissions)
         } else {
-            listener.onPermissionsResult(currentStatus)
+            listeners.onPermissionsResult(currentStatus)
         }
     }
 
@@ -95,7 +97,8 @@ internal open /* open for testing */ class ResultLauncherRuntimePermissionHandle
         this.pendingPermissions = null
         // Get the listener for this set of permissions.
         // If it's null, the permissions can't be notified.
-        val listener = listeners[pendingPermissions.toSet()] ?: return
+        val listeners = listeners[pendingPermissions.toSet()]
+        if (listeners.isNullOrEmpty()) return
         val context = requireContext()
         val result = pendingPermissions.map { permission ->
             val isGranted = permissionsResult.getOrElse(permission) { context.isPermissionGranted(permission) }
@@ -105,7 +108,11 @@ internal open /* open for testing */ class ResultLauncherRuntimePermissionHandle
                 else -> PermissionStatus.Denied.Permanently(permission)
             }
         }
-        listener.onPermissionsResult(result)
+        listeners.onPermissionsResult(result)
+    }
+
+    private fun Set<RuntimePermissionHandler.Listener>.onPermissionsResult(result: List<PermissionStatus>) {
+        forEach { listener -> listener.onPermissionsResult(result) }
     }
 
     companion object {

--- a/kpermissions/src/test/kotlin/com/fondesa/kpermissions/request/runtime/ResultLauncherRuntimePermissionHandlerTest.kt
+++ b/kpermissions/src/test/kotlin/com/fondesa/kpermissions/request/runtime/ResultLauncherRuntimePermissionHandlerTest.kt
@@ -319,6 +319,33 @@ class ResultLauncherRuntimePermissionHandlerTest {
         assertEquals(listOf(permissions.map(PermissionStatus::Granted)), listener.receivedPermissionsStatus)
     }
 
+    @Test
+    fun `When multiple different listeners are attached and result is received, all the listeners are notified`() {
+        val firstListener = FakeRuntimePermissionHandlerListener()
+        val secondListener = FakeRuntimePermissionHandlerListener()
+        fragment.attachListener(permissions, firstListener)
+        fragment.attachListener(permissions, secondListener)
+        fragment.handleRuntimePermissions(permissions)
+
+        fragment.onPermissionsResult(firstPermission to true, secondPermission to true)
+
+        val expectedResult = permissions.map(PermissionStatus::Granted)
+        assertEquals(listOf(expectedResult), firstListener.receivedPermissionsStatus)
+        assertEquals(listOf(expectedResult), secondListener.receivedPermissionsStatus)
+    }
+
+    @Test
+    fun `When same listener is attached multiple times and result is received, listener is notified once`() {
+        fragment.attachListener(permissions, listener)
+        fragment.attachListener(permissions, listener)
+        fragment.handleRuntimePermissions(permissions)
+
+        fragment.onPermissionsResult(firstPermission to true, secondPermission to true)
+
+        val expectedResult = permissions.map(PermissionStatus::Granted)
+        assertEquals(listOf(expectedResult), listener.receivedPermissionsStatus)
+    }
+
     internal class TestResultLauncherRuntimePermissionHandler : ResultLauncherRuntimePermissionHandler() {
         private val shouldShowRequestPermissionRationaleResults = mutableMapOf<String, Boolean>()
 


### PR DESCRIPTION
<!-- Make sure you've read the file `CONTRIBUTING.md` before submit the PR. -->

### Description
<!--
Describe the changes you have made on a high level in the project.
If this PR is related to an issue, reference it here.
-->
This PR allows multiple `PermissionRequest` instances in the same class.

### Motivation
<!--
If this solves a bug, provide the steps to reproduce it or reference the issue, if opened.
In the other cases, specify why this change or this new feature is required or why
it can be helpful to the other users. 
-->
Currently, if multiple `PermissionRequest` instances are built in the same class, the internal listeners of the first request are overridden with the second one.
This PR should solve this issue. More info at https://github.com/fondesa/kpermissions/issues/303.
