### PR TITLE
Remove ReleasesHub

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ buildscript {
         classpath libs.kotlin.gp
         classpath libs.kpermissions.buildTools
         classpath libs.ktlint.gp
-        classpath libs.releasesHub.gp
     }
 }
 
@@ -34,24 +33,6 @@ allprojects {
     apply from: rootProject.file("build-tools/kotlin.gradle")
     // Adds the version of this library to all the projects, including the root project.
     apply plugin: "kpermissions-version"
-}
-
-apply plugin: "com.dipien.releaseshub.gradle.plugin"
-
-releasesHub {
-    autoDetectDependenciesPaths = false
-    dependenciesPaths = [
-            "gradle/libs.versions.toml",
-            "gradle/wrapper/gradle-wrapper.properties"
-    ]
-    pullRequestLabels = ["dependencies"]
-    headBranchPrefix = "update-dependency/"
-    gitHubRepositoryOwner = "fondesa"
-    gitHubRepositoryName = "kpermissions"
-    excludes = [
-            // Excluded because since the version 3.1.0 the minimum supported Android version is 21.
-            "io.reactivex.rxjava3:rxjava"
-    ]
 }
 
 apply plugin: "com.github.breadmoirai.github-release"
@@ -69,7 +50,6 @@ githubRelease {
 def gitHubToken = project.properties["github.token"] ?: System.getenv("GITHUB_TOKEN")
 if (gitHubToken != null) {
     githubRelease.token = gitHubToken
-    releasesHub.gitHubWriteToken = gitHubToken
 }
 
 task clean(type: Delete) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# Do NOT use the [versions] tag because it's not supported by ReleasesHub.
-
 [libraries]
 android-gp-api = "com.android.tools.build:gradle-api:7.4.0"
 android-gp-impl = "com.android.tools.build:gradle:7.4.0"
@@ -34,7 +32,6 @@ kotlin-reflect = "org.jetbrains.kotlin:kotlin-reflect:1.8.0"
 kpermissions-buildTools = { module = "com.fondesa.kpermissions.buildtools:build-tools" }
 ktlint-gp = "org.jlleitschuh.gradle:ktlint-gradle:11.0.0"
 leakCanary = "com.squareup.leakcanary:leakcanary-android:2.10"
-releasesHub-gp = "com.dipien:releases-hub-gradle-plugin:4.0.0"
 robolectric = "org.robolectric:robolectric:4.9.2"
 rxJava2 = "io.reactivex.rxjava2:rxjava:2.2.21"
 rxJava3 = "io.reactivex.rxjava3:rxjava:3.0.13"


### PR DESCRIPTION
Since now Renovate is configured, ReleasesHub can be replaced.