### PR TITLE
Ignore RxJava3 updates due to minSdk compatibility

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "ignoreDeps": [
+    "io.reactivex.rxjava3:rxjava"
   ]
 }


### PR DESCRIPTION
The updates of RxJava3 should be ignored since RxJava minSdk is now 21.